### PR TITLE
Add B3 historical data helpers and package split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/gabrielguarisa/brdata"><img src="logo.png" alt="brdata"></a>
+  <a href="https://github.com/gabrielguarisa/brdata"><img src="https://raw.githubusercontent.com/gabrielguarisa/brdata/main/logo.png" alt="brdata"></a>
 </p>
 <p align="center">
     <em>Fontes de dados do mercado financeiro brasileiro</em>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brasil-data"
-version = "2.2.0"
+version = "2.3.0"
 description = "Brazilian financial market data sources"
 readme = "README.md"
 authors = [

--- a/src/brdata/b3/__init__.py
+++ b/src/brdata/b3/__init__.py
@@ -1,0 +1,8 @@
+from . import history, indexes
+from .history import *
+from .indexes import *
+
+from .history import __all__ as _history_all
+from .indexes import __all__ as _indexes_all
+
+__all__ = [*_indexes_all, *_history_all]

--- a/src/brdata/b3/history.py
+++ b/src/brdata/b3/history.py
@@ -1,0 +1,368 @@
+import datetime as dt
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+COTAHIST_BASE_URL = "https://bvmf.bmfbovespa.com.br/InstDados/SerHist"
+DEFAULT_COTAHIST_PATH = "data/landing/b3/cotahist"
+COTAHIST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0 Safari/537.36"
+    ),
+    "Accept": "application/zip,application/octet-stream,*/*",
+}
+
+
+@dataclass(frozen=True)
+class CotahistFile:
+    series: str
+    ref: str
+    filename: str
+
+    @property
+    def url(self) -> str:
+        return f"{COTAHIST_BASE_URL}/{self.filename}"
+
+    @property
+    def txt_filename(self) -> str:
+        return self.filename.removesuffix(".ZIP") + ".TXT"
+
+
+def annual_file(year: int) -> CotahistFile:
+    """Returns metadata for a yearly COTAHIST file."""
+    return CotahistFile(
+        series="annual",
+        ref=str(year),
+        filename=f"COTAHIST_A{year}.ZIP",
+    )
+
+
+def monthly_file(year: int, month: int) -> CotahistFile:
+    """Returns metadata for a monthly COTAHIST file."""
+    _validate_month(month)
+    return CotahistFile(
+        series="monthly",
+        ref=f"{year}-{month:02d}",
+        filename=f"COTAHIST_M{month:02d}{year}.ZIP",
+    )
+
+
+def daily_file(date: dt.date | str) -> CotahistFile:
+    """Returns metadata for a daily COTAHIST file."""
+    date = _parse_date(date)
+    return CotahistFile(
+        series="daily",
+        ref=date.isoformat(),
+        filename=f"COTAHIST_D{date:%d%m%Y}.ZIP",
+    )
+
+
+def is_zip_file(path: str | Path) -> bool:
+    """Checks whether a path points to a valid ZIP file."""
+    path = Path(path)
+    if not path.exists() or path.stat().st_size < 4:
+        return False
+
+    with path.open("rb") as file:
+        magic = file.read(4)
+
+    return magic == b"PK\x03\x04" and zipfile.is_zipfile(path)
+
+
+def download_file(
+    item: CotahistFile,
+    output_dir: str | Path = DEFAULT_COTAHIST_PATH,
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+) -> Path | None:
+    """Downloads a COTAHIST file."""
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = output_dir / item.filename
+
+    if output_path.exists() and not overwrite:
+        if not validate_zip or is_zip_file(output_path):
+            return output_path
+
+    tmp_path = output_path.with_suffix(output_path.suffix + ".part")
+
+    try:
+        with requests.get(
+            item.url,
+            headers=COTAHIST_HEADERS,
+            stream=True,
+            timeout=timeout,
+        ) as response:
+            if response.status_code == 404:
+                return None
+
+            response.raise_for_status()
+            if _is_html_response(response):
+                return None
+
+            total_bytes = _write_response_content(response, tmp_path)
+            if total_bytes == 0:
+                tmp_path.unlink(missing_ok=True)
+                return None
+
+            tmp_path.replace(output_path)
+
+            if validate_zip and not is_zip_file(output_path):
+                output_path.unlink(missing_ok=True)
+                return None
+
+            return output_path
+
+    except requests.RequestException:
+        tmp_path.unlink(missing_ok=True)
+        return None
+
+
+def download_annual_series(
+    year: int,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/annual",
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+) -> Path | None:
+    """Downloads the yearly COTAHIST series for a year."""
+    return download_file(
+        item=annual_file(year),
+        output_dir=output_dir,
+        overwrite=overwrite,
+        validate_zip=validate_zip,
+        timeout=timeout,
+    )
+
+
+def download_monthly_series(
+    year: int,
+    month: int,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/monthly",
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+) -> Path | None:
+    """Downloads the monthly COTAHIST series for a month."""
+    return download_file(
+        item=monthly_file(year, month),
+        output_dir=output_dir,
+        overwrite=overwrite,
+        validate_zip=validate_zip,
+        timeout=timeout,
+    )
+
+
+def download_daily_series(
+    date: dt.date | str,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/daily",
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+) -> Path | None:
+    """Downloads the daily COTAHIST series for a date."""
+    return download_file(
+        item=daily_file(date),
+        output_dir=output_dir,
+        overwrite=overwrite,
+        validate_zip=validate_zip,
+        timeout=timeout,
+    )
+
+
+def iter_months(
+    start_year: int,
+    start_month: int,
+    end_year: int,
+    end_month: int,
+) -> Iterable[tuple[int, int]]:
+    """Iterates over months in a closed interval."""
+    _validate_month(start_month)
+    _validate_month(end_month)
+    current = dt.date(start_year, start_month, 1)
+    end = dt.date(end_year, end_month, 1)
+
+    if current > end:
+        raise ValueError("Start month cannot be greater than end month")
+
+    while current <= end:
+        yield current.year, current.month
+
+        if current.month == 12:
+            current = dt.date(current.year + 1, 1, 1)
+        else:
+            current = dt.date(current.year, current.month + 1, 1)
+
+
+def iter_dates(
+    start_date: dt.date | str,
+    end_date: dt.date | str,
+    weekdays_only: bool = False,
+) -> Iterable[dt.date]:
+    """Iterates over dates in a closed interval."""
+    start_date = _parse_date(start_date)
+    end_date = _parse_date(end_date)
+
+    if start_date > end_date:
+        raise ValueError("Start date cannot be greater than end date")
+
+    current = start_date
+
+    while current <= end_date:
+        if not weekdays_only or current.weekday() < 5:
+            yield current
+
+        current += dt.timedelta(days=1)
+
+
+def download_annual_series_range(
+    start_year: int,
+    end_year: int,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/annual",
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+    sleep: float = 1.0,
+) -> list[Path]:
+    """Downloads yearly COTAHIST series within a year range."""
+    if start_year > end_year:
+        raise ValueError("Start year cannot be greater than end year")
+
+    downloaded: list[Path] = []
+
+    for year in range(start_year, end_year + 1):
+        path = download_annual_series(
+            year=year,
+            output_dir=output_dir,
+            overwrite=overwrite,
+            validate_zip=validate_zip,
+            timeout=timeout,
+        )
+
+        if path is not None:
+            downloaded.append(path)
+
+        _sleep(sleep)
+
+    return downloaded
+
+
+def download_monthly_series_range(
+    start_year: int,
+    start_month: int,
+    end_year: int,
+    end_month: int,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/monthly",
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+    sleep: float = 1.0,
+) -> list[Path]:
+    """Downloads monthly COTAHIST series within a month range."""
+    downloaded: list[Path] = []
+
+    for year, month in iter_months(start_year, start_month, end_year, end_month):
+        path = download_monthly_series(
+            year=year,
+            month=month,
+            output_dir=output_dir,
+            overwrite=overwrite,
+            validate_zip=validate_zip,
+            timeout=timeout,
+        )
+
+        if path is not None:
+            downloaded.append(path)
+
+        _sleep(sleep)
+
+    return downloaded
+
+
+def download_daily_series_range(
+    start_date: dt.date | str,
+    end_date: dt.date | str,
+    output_dir: str | Path = f"{DEFAULT_COTAHIST_PATH}/daily",
+    weekdays_only: bool = True,
+    overwrite: bool = False,
+    validate_zip: bool = True,
+    timeout: int = 60,
+    sleep: float = 1.0,
+) -> list[Path]:
+    """Downloads daily COTAHIST series within a date range."""
+    downloaded: list[Path] = []
+
+    for date in iter_dates(start_date, end_date, weekdays_only=weekdays_only):
+        path = download_daily_series(
+            date=date,
+            output_dir=output_dir,
+            overwrite=overwrite,
+            validate_zip=validate_zip,
+            timeout=timeout,
+        )
+
+        if path is not None:
+            downloaded.append(path)
+
+        _sleep(sleep)
+
+    return downloaded
+
+
+def _parse_date(date: dt.date | str) -> dt.date:
+    if isinstance(date, str):
+        return dt.date.fromisoformat(date)
+    return date
+
+
+def _validate_month(month: int) -> None:
+    if not 1 <= month <= 12:
+        raise ValueError("month must be between 1 and 12")
+
+
+def _is_html_response(response: requests.Response) -> bool:
+    content_type = response.headers.get("content-type", "").lower()
+    return "html" in content_type
+
+
+def _write_response_content(response: requests.Response, output_path: Path) -> int:
+    total_bytes = 0
+
+    with output_path.open("wb") as file:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            if chunk:
+                file.write(chunk)
+                total_bytes += len(chunk)
+
+    return total_bytes
+
+
+def _sleep(seconds: float) -> None:
+    if seconds > 0:
+        time.sleep(seconds)
+
+
+__all__ = [
+    "CotahistFile",
+    "annual_file",
+    "monthly_file",
+    "daily_file",
+    "is_zip_file",
+    "download_file",
+    "download_annual_series",
+    "download_monthly_series",
+    "download_daily_series",
+    "iter_months",
+    "iter_dates",
+    "download_annual_series_range",
+    "download_monthly_series_range",
+    "download_daily_series_range",
+]

--- a/src/brdata/b3/indexes.py
+++ b/src/brdata/b3/indexes.py
@@ -1,6 +1,6 @@
-import os
 import base64
 import json
+import os
 import time
 from datetime import datetime
 from enum import StrEnum
@@ -210,4 +210,10 @@ def download_indexes(
     return indexes_data
 
 
-__all__ = ["B3Index", "list_indexes", "download_index", "download_indexes"]
+__all__ = [
+    "B3Index",
+    "list_indexes",
+    "params_to_base64",
+    "download_index",
+    "download_indexes",
+]

--- a/tests/test_b3_history.py
+++ b/tests/test_b3_history.py
@@ -1,0 +1,66 @@
+import datetime as dt
+import io
+import zipfile
+
+from brdata.b3 import history
+
+
+def _zip_bytes(filename: str = "COTAHIST.TXT", content: bytes = b"data") -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_file:
+        zip_file.writestr(filename, content)
+    return buffer.getvalue()
+
+
+def test_cotahist_file_builders():
+    annual = history.annual_file(2026)
+    monthly = history.monthly_file(2026, 5)
+    daily = history.daily_file("2026-05-15")
+
+    assert annual.filename == "COTAHIST_A2026.ZIP"
+    assert annual.txt_filename == "COTAHIST_A2026.TXT"
+    assert monthly.filename == "COTAHIST_M052026.ZIP"
+    assert daily.filename == "COTAHIST_D15052026.ZIP"
+    assert daily.ref == "2026-05-15"
+
+
+def test_iter_months_returns_closed_interval():
+    months = list(history.iter_months(2025, 11, 2026, 2))
+
+    assert months == [(2025, 11), (2025, 12), (2026, 1), (2026, 2)]
+
+
+def test_iter_dates_skips_weekends_when_requested():
+    dates = list(history.iter_dates("2026-05-15", "2026-05-18", weekdays_only=True))
+
+    assert dates == [dt.date(2026, 5, 15), dt.date(2026, 5, 18)]
+
+
+def test_download_file_writes_valid_zip(tmp_path, mocker):
+    response = mocker.Mock()
+    response.__enter__ = mocker.Mock(return_value=response)
+    response.__exit__ = mocker.Mock(return_value=None)
+    response.status_code = 200
+    response.headers = {"content-type": "application/zip"}
+    response.iter_content.return_value = [_zip_bytes()]
+
+    mock_get = mocker.patch("brdata.b3.history.requests.get", return_value=response)
+
+    path = history.download_file(history.annual_file(2026), output_dir=tmp_path)
+
+    assert path == tmp_path / "COTAHIST_A2026.ZIP"
+    assert history.is_zip_file(path)
+    mock_get.assert_called_once()
+
+
+def test_download_file_returns_none_for_404(tmp_path, mocker):
+    response = mocker.Mock()
+    response.__enter__ = mocker.Mock(return_value=response)
+    response.__exit__ = mocker.Mock(return_value=None)
+    response.status_code = 404
+    response.headers = {}
+    mocker.patch("brdata.b3.history.requests.get", return_value=response)
+
+    path = history.download_file(history.annual_file(2026), output_dir=tmp_path)
+
+    assert path is None

--- a/tests/test_b3_indexes.py
+++ b/tests/test_b3_indexes.py
@@ -3,10 +3,9 @@ import json
 from enum import StrEnum
 
 import pytest
-from brdata import b3
+from brdata.b3 import indexes
 
 
-# 1. Teste de Conversão Base64 - Parametrizado
 @pytest.mark.parametrize(
     "params, expected",
     [
@@ -15,36 +14,34 @@ from brdata import b3
     ],
 )
 def test_params_to_base64(params, expected):
-    assert b3.params_to_base64(params) == expected
+    assert indexes.params_to_base64(params) == expected
 
 
 def test_b3_index_is_str_enum():
-    assert issubclass(b3.B3Index, StrEnum)
-    assert b3.B3Index.IBOV.value == "IBOV"
-    assert b3.B3Index.IBOV == "IBOV"
+    assert issubclass(indexes.B3Index, StrEnum)
+    assert indexes.B3Index.IBOV.value == "IBOV"
+    assert indexes.B3Index.IBOV == "IBOV"
 
 
 def test_list_indexes_returns_available_indexes():
-    indexes = b3.list_indexes()
+    available_indexes = indexes.list_indexes()
 
-    assert indexes[0] == "IBOV"
-    assert "IFIX" in indexes
-    assert indexes == [index.value for index in b3.B3Index]
+    assert available_indexes[0] == "IBOV"
+    assert "IFIX" in available_indexes
+    assert available_indexes == [index.value for index in indexes.B3Index]
 
 
 def test_format_date_to_iso_raises_on_invalid_date():
     with pytest.raises(ValueError, match="Invalid B3 date format: 2026-05-14"):
-        b3._format_date_to_iso("2026-05-14")
+        indexes._format_date_to_iso("2026-05-14")
 
 
 def test_download_index_raises_on_invalid_index():
     with pytest.raises(ValueError, match="Index MOEDA_FAKE Not Found"):
-        b3.download_index("MOEDA_FAKE")
+        indexes.download_index("MOEDA_FAKE")
 
 
-# 2. Teste de Sucesso - Download Simples
 def test_download_index_sucess(mocker):
-    # Mock do requests para retornar JSON da B3
     mock_response = mocker.Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
@@ -52,13 +49,11 @@ def test_download_index_sucess(mocker):
         "page": {"totalPages": 1},
     }
 
-    mock_get = mocker.patch("brdata.b3.requests.get", return_value=mock_response)
-
-    # Mocks de sistema de arquivos
-    mock_makedirs = mocker.patch("brdata.b3.os.makedirs")
+    mock_get = mocker.patch("brdata.b3.indexes.requests.get", return_value=mock_response)
+    mock_makedirs = mocker.patch("brdata.b3.indexes.os.makedirs")
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
 
-    data = b3.download_index("ibov")
+    data = indexes.download_index("ibov")
 
     assert data == {
         "results": [{"cod": "PETR4", "part": "5.0"}],
@@ -80,9 +75,9 @@ def test_download_index_day_portfolio_includes_date_and_segment(mocker):
         "results": [{"cod": "PETR4", "part": "5.0"}],
         "page": {"totalPages": 1},
     }
-    mock_get = mocker.patch("brdata.b3.requests.get", return_value=mock_response)
+    mock_get = mocker.patch("brdata.b3.indexes.requests.get", return_value=mock_response)
 
-    data = b3.download_index("ibov", theoretical=False)
+    data = indexes.download_index("ibov", theoretical=False)
 
     assert data == {
         "date": "2026-05-14",
@@ -102,13 +97,12 @@ def test_download_index_day_portfolio_raises_when_date_missing(mocker):
         "results": [{"cod": "PETR4", "part": "5.0"}],
         "page": {"totalPages": 1},
     }
-    mocker.patch("brdata.b3.requests.get", return_value=mock_response)
+    mocker.patch("brdata.b3.indexes.requests.get", return_value=mock_response)
 
     with pytest.raises(Exception, match="Date Not Found for IBOV"):
-        b3.download_index("IBOV", theoretical=False)
+        indexes.download_index("IBOV", theoretical=False)
 
 
-# 3. Teste de Paginação - Mesclagem de resultados
 def test_download_index_pagination_merging(mocker):
     resp_pg1 = mocker.Mock()
     resp_pg1.status_code = 200
@@ -124,16 +118,17 @@ def test_download_index_pagination_merging(mocker):
         "page": {"totalPages": 2},
     }
 
-    # Simula duas chamadas sequenciais para o requests.get
-    mock_get = mocker.patch("brdata.b3.requests.get", side_effect=[resp_pg1, resp_pg2])
-    mocker.patch("brdata.b3.os.makedirs")
-    mocker.patch("brdata.b3.os.path.exists", return_value=False)
-    mocker.patch("brdata.b3.time.sleep")  # Remove espera real para o teste ser rápido
+    mock_get = mocker.patch(
+        "brdata.b3.indexes.requests.get", side_effect=[resp_pg1, resp_pg2]
+    )
+    mocker.patch("brdata.b3.indexes.os.makedirs")
+    mocker.patch("brdata.b3.indexes.os.path.exists", return_value=False)
+    mocker.patch("brdata.b3.indexes.time.sleep")
 
-    mock_json_dump = mocker.patch("brdata.b3.json.dump")
+    mock_json_dump = mocker.patch("brdata.b3.indexes.json.dump")
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
 
-    b3.download_index("IBOV", path="data/landing/b3")
+    indexes.download_index("IBOV", path="data/landing/b3")
 
     assert mock_get.call_count == 2
     dados_finais = mock_json_dump.call_args[0][0]
@@ -152,39 +147,35 @@ def test_download_index_day_portfolio_uses_separate_file(mocker):
         "results": [{"cod": "PETR4", "part": "5.0"}],
         "page": {"totalPages": 1},
     }
-    mocker.patch("brdata.b3.requests.get", return_value=mock_response)
-    mocker.patch("brdata.b3.os.makedirs")
-    mocker.patch("brdata.b3.os.path.exists", return_value=False)
+    mocker.patch("brdata.b3.indexes.requests.get", return_value=mock_response)
+    mocker.patch("brdata.b3.indexes.os.makedirs")
+    mocker.patch("brdata.b3.indexes.os.path.exists", return_value=False)
     mock_open = mocker.patch("builtins.open", mocker.mock_open())
 
-    b3.download_index("IBOV", path="data/landing/b3", theoretical=False)
+    indexes.download_index("IBOV", path="data/landing/b3", theoretical=False)
 
     mock_open.assert_called_once_with(
         "data/landing/b3/IBOV_day.json", "w", encoding="utf-8"
     )
 
 
-# 4. Teste de Validação - Pular índices inválidos
 def test_download_indexes_skips_invalid(mocker):
     index_data = {"results": []}
     mock_singular = mocker.patch(
-        "brdata.b3.download_index",
+        "brdata.b3.indexes.download_index",
         side_effect=[index_data, ValueError("Index MOEDA_FAKE Not Found")],
     )
-    # Mock do tqdm como MagicMock para suportar tqdm.write()
-    mock_tqdm = mocker.patch("brdata.b3.tqdm")
+    mock_tqdm = mocker.patch("brdata.b3.indexes.tqdm")
     mock_tqdm.side_effect = lambda x, **kwargs: x
 
     lista_teste = ["IBOV", "MOEDA_FAKE"]
-    result = b3.download_indexes(lista_teste)
+    result = indexes.download_indexes(lista_teste)
 
-    # Deve baixar apenas o IBOV
     assert result == {"IBOV": index_data}
     assert mock_singular.call_count == 2
     mock_tqdm.write.assert_called_once_with("Index MOEDA_FAKE Not Found")
 
 
-# 5. Teste de Erro - Resultados vazios
 def test_download_index_raises_exception_on_empty_results(mocker):
     mock_response = mocker.Mock()
     mock_response.status_code = 200
@@ -192,26 +183,25 @@ def test_download_index_raises_exception_on_empty_results(mocker):
         "results": [],
         "page": {"totalPages": 0},
     }
-    mocker.patch("brdata.b3.requests.get", return_value=mock_response)
-    mocker.patch("brdata.b3.os.makedirs")
+    mocker.patch("brdata.b3.indexes.requests.get", return_value=mock_response)
+    mocker.patch("brdata.b3.indexes.os.makedirs")
 
     with pytest.raises(Exception, match="Data Not Found for IBOV"):
-        b3.download_index("IBOV")
+        indexes.download_index("IBOV")
 
 
 def test_download_index_raises_index_error_on_request_failure(mocker):
-    mocker.patch("brdata.b3.requests.get", side_effect=Exception("Network Error"))
+    mocker.patch("brdata.b3.indexes.requests.get", side_effect=Exception("Network Error"))
 
     with pytest.raises(Exception, match="Index Error IBOV: Network Error"):
-        b3.download_index("IBOV")
+        indexes.download_index("IBOV")
 
 
-# 6. Teste de Inteligência - Respeitar Overwrite
 def test_download_index_respects_overwrite(mocker):
-    mocker.patch("brdata.b3.os.path.exists", return_value=True)
-    mocker.patch("brdata.b3.os.makedirs")
+    mocker.patch("brdata.b3.indexes.os.path.exists", return_value=True)
+    mocker.patch("brdata.b3.indexes.os.makedirs")
     mocker.patch("builtins.open", mocker.mock_open(read_data='{"cached": true}'))
 
-    result = b3.download_index("IBOV", path="data/landing/b3", overwrite=False)
+    result = indexes.download_index("IBOV", path="data/landing/b3", overwrite=False)
 
     assert result == {"cached": True}


### PR DESCRIPTION
## Summary
Improve B3 support with historical COTAHIST download helpers, reorganize exports into a unified package namespace, and update the project version.

## Changes
- Added COTAHIST utilities for annual, monthly, and daily series
- Introduced file builders, range iterators, ZIP validation, and safer download handling for missing or HTML responses
- Reorganized B3 functionality so index and history APIs are exported from a single package namespace
- Extended the public index export surface with parameter encoding helpers
- Fixed README logo rendering on GitHub
- Bumped the package version to 2.3.0
