### PR TITLE
fix: adjust focus download filename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brasil-data"
-version = "3.0.0"
+version = "3.0.1"
 description = "Brazilian financial market data sources"
 readme = "README.md"
 authors = [

--- a/src/brdata/bacen/boletim_focus.py
+++ b/src/brdata/bacen/boletim_focus.py
@@ -47,6 +47,8 @@ class BoletimFocus:
 
         data = response.json().get("value", [])
         filename = f"{endpoint}.json"
+        if start_date:
+            filename = f"{endpoint}_{start_date}.json"
 
         if path:
             write_to_disk(data, filename, path)


### PR DESCRIPTION
## Fix
Focus download filename adjusted to allow multiple files on disk.

## Changes
- File naming structure changed to `{endpoint}_{start_date}.json`, if a "start_date exists". This allows for the download of multiple files.
- Version bumped to **3.0.1**