### PR TITLE
F/selic standardized date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brasil-data"
-version = "3.0.1"
+version = "4.0.0"
 description = "Brazilian financial market data sources"
 readme = "README.md"
 authors = [

--- a/src/brdata/bacen/selic.py
+++ b/src/brdata/bacen/selic.py
@@ -1,37 +1,49 @@
 import requests
-from datetime import date
+from datetime import date, datetime
 from typing import Literal
 
-from .utils import write_to_disk
+from .utils import write_to_disk, date_validator
 
 def fetch_selic(
-        category: Literal["meta", "diaria"],
-        start_date: str = None,
-        end_date: str = None,
-        path: str = None
+    category: Literal["meta", "diaria"],
+    start_date: str = None,
+    end_date: str = None,
+    path: str = None
 ):
-    
     """
     Fetches 'Selic Meta' or 'Selic Diária' data.
     It can be downloaded directly if a file path is provided.
-    \nDate format: str = 'dd/mm/yyyy'
-    \n- The difference between the start and end dates cannot exceed 10 years.
+    
+    Date format: str = 'YYYY-MM-DD'
+    - The difference between the start and end dates cannot exceed 10 years.
     """
-    start_date = start_date or date.today().strftime('%d/%m/%Y')
+
+    if start_date:
+        date_validator(start_date) 
+        parsed_start = datetime.strptime(start_date, "%Y-%m-%d")
+        valid_start_date = parsed_start.strftime("%d/%m/%Y")
+        file_date_suffix = start_date
+    else:
+        today = date.today()
+        valid_start_date = today.strftime("%d/%m/%Y")
+        file_date_suffix = today.strftime("%Y-%m-%d")
 
     if category == "meta":
         url_bcb = "https://api.bcb.gov.br/dados/serie/bcdata.sgs.432/dados"
-        filename = f"selic_meta_{start_date.replace("/", "-")}.json"
+        filename = f"selic_meta_{file_date_suffix}.json"
     else:
         url_bcb = "https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados"
-        filename = f"selic_diaria_{start_date.replace("/", "-")}.json"
+        filename = f"selic_diaria_{file_date_suffix}.json"
 
     params = {
         "formato": "json",
-        "dataInicial": start_date
+        "dataInicial": valid_start_date
     }
+
     if end_date:
-        params["dataFinal"] = end_date
+        date_validator(end_date)
+        parsed_end = datetime.strptime(end_date, "%Y-%m-%d")
+        params["dataFinal"] = parsed_end.strftime("%d/%m/%Y")
 
     try:
         response = requests.get(url_bcb, params=params)

--- a/tests/test_bacen_selic.py
+++ b/tests/test_bacen_selic.py
@@ -1,36 +1,41 @@
-import pytest
-from unittest.mock import patch, MagicMock
 from datetime import date
+from unittest.mock import MagicMock, patch
+import pytest
 import requests
 
 from src.brdata.bacen.selic import fetch_selic
 
+
 @patch("src.brdata.bacen.selic.requests.get")
 def test_fetch_selic_meta_sucesso(mock_get):
-    """testa a busca de selic meta com sucesso, sem salvar em arquivo"""
+    """Testa a busca de Selic Meta com sucesso no formato ISO, sem salvar em arquivo."""
     mock_response = MagicMock()
     dados_falsos = [{"data": "20/05/2026", "valor": "10.50"}]
     mock_response.json.return_value = dados_falsos
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    resultado = fetch_selic(category="meta", start_date="01/05/2026")
+    # Entrada em ISO: YYYY-MM-DD
+    resultado = fetch_selic(category="meta", start_date="2026-05-01")
 
     assert resultado == dados_falsos
+    # A API deve receber formatado em DD/MM/YYYY
     mock_get.assert_called_once_with(
         "https://api.bcb.gov.br/dados/serie/bcdata.sgs.432/dados",
-        params={"formato": "json", "dataInicial": "01/05/2026"}
+        params={"formato": "json", "dataInicial": "01/05/2026"},
     )
+
 
 @patch("src.brdata.bacen.selic.requests.get")
 def test_fetch_selic_diaria_com_data_final(mock_get):
-    """Testa a busca de Selic Diária incluindo o parâmetro end_date."""
+    """Testa a busca de Selic Diária incluindo end_date no formato ISO."""
     mock_response = MagicMock()
     mock_response.json.return_value = []
     mock_get.return_value = mock_response
 
+    # Entradas em ISO
     fetch_selic(
-        category="diaria", start_date="01/01/2026", end_date="31/01/2026"
+        category="diaria", start_date="2026-01-01", end_date="2026-01-31"
     )
 
     mock_get.assert_called_once_with(
@@ -46,20 +51,21 @@ def test_fetch_selic_diaria_com_data_final(mock_get):
 @patch("src.brdata.bacen.selic.write_to_disk")
 @patch("src.brdata.bacen.selic.requests.get")
 def test_fetch_selic_salvando_no_disco(mock_get, mock_write):
-    """Testa se a função chama corretamente o write_to_disk quando passamos um path."""
+    """Testa se a função gera o nome de arquivo ISO limpo ao passar um path."""
     mock_response = MagicMock()
     dados_falsos = [{"data": "20/05/2026", "valor": "10.50"}]
     mock_response.json.return_value = dados_falsos
     mock_get.return_value = mock_response
 
     resultado = fetch_selic(
-        category="meta", start_date="20/05/2026", path="/downloads"
+        category="meta", start_date="2026-05-20", path="/downloads"
     )
 
     assert resultado is None
 
+    # O arquivo deve utilizar o sufixo YYYY-MM-DD
     mock_write.assert_called_once_with(
-        dados_falsos, "selic_meta_20-05-2026.json", "/downloads"
+        dados_falsos, "selic_meta_2026-05-20.json", "/downloads"
     )
 
 
@@ -70,9 +76,15 @@ def test_fetch_selic_erro_na_requisicao(mock_get, capsys):
         "Erro de Conexão"
     )
 
-    resultado = fetch_selic(category="meta", start_date="01/05/2026")
+    resultado = fetch_selic(category="meta", start_date="2026-05-01")
 
     assert resultado is None
 
     captured = capsys.readouterr()
     assert "Error: Erro de Conexão" in captured.out
+
+
+def test_fetch_selic_formato_data_invalido():
+    """Testa se a função levanta ValueError ao passar data fora do padrão ISO."""
+    with pytest.raises(ValueError):
+        fetch_selic(category="meta", start_date="01/05/2026")


### PR DESCRIPTION
## Summary
Refactored the `fetch_selic` function to standardize date inputs to the ISO standard (`YYYY-MM-DD`). The function now strictly expects user-provided dates in this format and handles the required conversion to the Central Bank API format (`DD/MM/YYYY`) internally.

## Changes
- **Input Format Standardized:** `start_date` and `end_date` parameters now strictly accept ISO format (`YYYY-MM-DD`).
- **Internal Conversion:** Automatic formatting of dates to `DD/MM/YYYY` when building the query parameters for the Bacen API.
- **File Naming:** Updated the disk filename output to use a clean ISO suffix (e.g., `selic_meta_2026-05-20.json`).
- **Unit Tests:** Updated all test cases in `test_selic.py` to reflect the updated interface and added a test for invalid date formats.
- Bump version to `4.0.0`